### PR TITLE
Support macOS frameworks.

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -22,9 +22,7 @@ jobs:
     -
       name: Install toolchain
       run: |
-        alr --non-interactive config --global --set toolchain.assistant false
-        alr --non-interactive toolchain --install gnat_native
-        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive settings --global --set toolchain.assistant false
         alr --non-interactive toolchain --select gnat_native
         alr --non-interactive toolchain --select gprbuild
     -

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
     -
       name: alire-project/setup-alire
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v3
     -
       name: Install toolchain
       run: |

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -22,9 +22,7 @@ jobs:
     -
       name: Install toolchain
       run: |
-        alr --non-interactive config --global --set toolchain.assistant false
-        alr --non-interactive toolchain --install gnat_native
-        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive settings --global --set toolchain.assistant false
         alr --non-interactive toolchain --select gnat_native
         alr --non-interactive toolchain --select gprbuild
     -

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: CI on macOS
 
-    runs-on: macos-13
+    runs-on: macos-12
 
     steps:
     -

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: CI on macOS
 
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
     -
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
     -
       name: alire-project/setup-alire
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v3
     -
       name: Install toolchain
       run: |

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -22,9 +22,7 @@ jobs:
     -
       name: Install toolchain
       run: |
-        alr --non-interactive config --global --set toolchain.assistant false
-        alr --non-interactive toolchain --install gnat_native
-        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive settings --global --set toolchain.assistant false
         alr --non-interactive toolchain --select gnat_native
         alr --non-interactive toolchain --select gprbuild
     -

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
     -
       name: alire-project/setup-alire
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v3
     -
       name: Install toolchain
       run: |

--- a/alire.toml
+++ b/alire.toml
@@ -22,10 +22,10 @@ project-files = ["build/gnat/sdlada.gpr"] #, "build/gnat/"]
 [gpr-set-externals.'case(os)']
   linux   = { SDL_PLATFORM = "linux" }
   windows = { SDL_PLATFORM = "windows" }
-  macos   = { SDL_PLATFORM = "macosx" }
-# [gpr-set-externals.'case(distribution)']
-#   homebrew = { SDL_PLATFORM = "macos_homebrew" }
-#   macports = { SDL_PLATFORM = "macos_ports" }
+[gpr-set-externals.'case(os)'.macos.'case(distribution)']
+  homebrew = { SDL_PLATFORM = "macos_homebrew" }
+  macports = { SDL_PLATFORM = "macos_ports" }
+  '...'    = { SDL_PLATFORM = "macosx" }
 
 [[actions]]
   type = "pre-build"

--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -90,4 +90,9 @@ library project SDLAda is
       for Default_Switches ("C") use Common_Switches & C_Switches;
       for Default_Switches ("Ada") use Common_Switches & Ada_Switches;
    end Compiler;
+
+   package Linker is
+      for Default_Switches ("ada") use ("-Wl,-ld_classic");
+   end Linker;
+
 end SDLAda;

--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -90,9 +90,4 @@ library project SDLAda is
       for Default_Switches ("C") use Common_Switches & C_Switches;
       for Default_Switches ("Ada") use Common_Switches & Ada_Switches;
    end Compiler;
-
-   package Linker is
-      for Default_Switches ("ada") use ("-Wl,-ld_classic");
-   end Linker;
-
 end SDLAda;

--- a/build/gnat/tools.gpr
+++ b/build/gnat/tools.gpr
@@ -1,6 +1,8 @@
 project Tools is
+   type Platform_Type is ("linux", "bsd", "windows", "macosx", "macos_homebrew", "macos_ports", "ios", "android");
    type Mode_Type is ("debug", "release");
 
+   Platform : Platform_Type := external ("SDL_PLATFORM", "linux");
    Mode : Mode_Type := external ("SDL_MODE", "debug");
 
    for Source_Dirs use ("../../tools");
@@ -31,7 +33,14 @@ project Tools is
    --     package Builder is
    --        for Default_Switches ("Ada") use ("-gnat2012", "-gnata"); --, "-gnatG");
    --     end Builder;
+
    package Linker is
-      for Default_Switches ("ada") use ("-Wl,-ld_classic");
+      case Platform is
+         when "macosx" | "macos_homebrew" | "macos_ports" =>
+            for Default_Switches ("ada") use ("-Wl,-ld_classic");
+         when others =>
+            null;
+      end case;
    end Linker;
+
 end Tools;

--- a/build/gnat/tools.gpr
+++ b/build/gnat/tools.gpr
@@ -34,13 +34,13 @@ project Tools is
    --        for Default_Switches ("Ada") use ("-gnat2012", "-gnata"); --, "-gnatG");
    --     end Builder;
 
-   package Linker is
-      case Platform is
-         when "macosx" | "macos_homebrew" | "macos_ports" =>
-            for Default_Switches ("ada") use ("-Wl,-ld_classic");
-         when others =>
-            null;
-      end case;
-   end Linker;
+   --  package Linker is
+   --     case Platform is
+   --        when "macosx" | "macos_homebrew" | "macos_ports" =>
+   --           for Default_Switches ("ada") use ("-Wl,-ld_classic");
+   --        when others =>
+   --           null;
+   --     end case;
+   --  end Linker;
 
 end Tools;

--- a/build/gnat/tools.gpr
+++ b/build/gnat/tools.gpr
@@ -31,4 +31,7 @@ project Tools is
    --     package Builder is
    --        for Default_Switches ("Ada") use ("-gnat2012", "-gnata"); --, "-gnatG");
    --     end Builder;
+   package Linker is
+      for Default_Switches ("ada") use ("-Wl,-ld_classic");
+   end Linker;
 end Tools;

--- a/src/link/macosx/sdl_linker.ads
+++ b/src/link/macosx/sdl_linker.ads
@@ -6,5 +6,8 @@
 package SDL_Linker is
    pragma Pure;
 
-   Options : constant String := "-framework SDL2";
+   pragma Linker_Options ("-F/Library/Frameworks");
+   pragma Linker_Options ("-framework");
+   pragma Linker_Options ("SDL2");
+
 end SDL_Linker;

--- a/src/link/nix/sdl_linker.ads
+++ b/src/link/nix/sdl_linker.ads
@@ -6,5 +6,5 @@
 package SDL_Linker is
    pragma Pure;
 
-   Options : constant String := "-lSDL2";
+   pragma Linker_Options ("-lSDL2");
 end SDL_Linker;

--- a/src/sdl.ads
+++ b/src/sdl.ads
@@ -10,7 +10,7 @@ with SDL_Linker;
 
 package SDL is
    pragma Pure;
-   pragma Linker_Options (SDL_Linker.Options);
+   pragma Unreferenced (SDL_Linker);
 
    package C renames Interfaces.C;
 

--- a/src/sdl.ads
+++ b/src/sdl.ads
@@ -10,7 +10,6 @@ with SDL_Linker;
 
 package SDL is
    pragma Pure;
-   pragma Unreferenced (SDL_Linker);
 
    package C renames Interfaces.C;
 


### PR DESCRIPTION
These changes allow users to import SDL2 using one of Homebrew, MacPorts or the framework from libsdl.org, in that order of preference.

For the framework option, there are two issues:
* the way that GCC is built means that it doesn't search for frameworks in /Library/Frameworks, so we have to tell it to.
* the linker option "-framework SDL2" has to be sent as two options, because that's how the linker ld needs to see it (as separate arguments).

  * alire.toml (gpr-set-externals): if the OS is macos, set SDL_PLATFORM to macos_homebrew (if 'brew' is on the PATH), macos_ports (if 'brew' isn't on the PATH but 'port' is), or macosx (if neither 'brew' nor 'port' is on the PATH).
  * src/sdl.ads (pragma Linker_Options): remove. (SDL_Linker): mark as unreferenced. (query: should it be moved to the body?)
  * src/link/macosx/sdl_linker.ads: remove Options. Add three Linker_Options, one to specify the location of the framework, one for the '-framework` switch, and one for 'SDL2'.
  * src/link/nix/sdl_linker.ads: replace Options by the equivalent pragma Linker_Options.