### PR TITLE
Support macOS frameworks; update CI workflows for alr v2(.0.1).

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -18,13 +18,11 @@ jobs:
       uses: actions/checkout@v4
     -
       name: alire-project/setup-alire
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v3
     -
       name: Install toolchain
       run: |
-        alr --non-interactive config --global --set toolchain.assistant false
-        alr --non-interactive toolchain --install gnat_native
-        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive settings --global --set toolchain.assistant false
         alr --non-interactive toolchain --select gnat_native
         alr --non-interactive toolchain --select gprbuild
     -

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: CI on macOS
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     -
@@ -18,13 +18,11 @@ jobs:
       uses: actions/checkout@v4
     -
       name: alire-project/setup-alire
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v3
     -
       name: Install toolchain
       run: |
-        alr --non-interactive config --global --set toolchain.assistant false
-        alr --non-interactive toolchain --install gnat_native
-        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive settings --global --set toolchain.assistant false
         alr --non-interactive toolchain --select gnat_native
         alr --non-interactive toolchain --select gprbuild
     -

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -18,13 +18,11 @@ jobs:
       uses: actions/checkout@v4
     -
       name: alire-project/setup-alire
-      uses: alire-project/setup-alire@v2
+      uses: alire-project/setup-alire@v3
     -
       name: Install toolchain
       run: |
-        alr --non-interactive config --global --set toolchain.assistant false
-        alr --non-interactive toolchain --install gnat_native
-        alr --non-interactive toolchain --install gprbuild
+        alr --non-interactive settings --global --set toolchain.assistant false
         alr --non-interactive toolchain --select gnat_native
         alr --non-interactive toolchain --select gprbuild
     -

--- a/alire.toml
+++ b/alire.toml
@@ -22,10 +22,10 @@ project-files = ["build/gnat/sdlada.gpr"] #, "build/gnat/"]
 [gpr-set-externals.'case(os)']
   linux   = { SDL_PLATFORM = "linux" }
   windows = { SDL_PLATFORM = "windows" }
-  macos   = { SDL_PLATFORM = "macosx" }
-# [gpr-set-externals.'case(distribution)']
-#   homebrew = { SDL_PLATFORM = "macos_homebrew" }
-#   macports = { SDL_PLATFORM = "macos_ports" }
+[gpr-set-externals.'case(os)'.macos.'case(distribution)']
+  homebrew = { SDL_PLATFORM = "macos_homebrew" }
+  macports = { SDL_PLATFORM = "macos_ports" }
+  '...'    = { SDL_PLATFORM = "macosx" }
 
 [[actions]]
   type = "pre-build"

--- a/src/link/macosx/sdl_linker.ads
+++ b/src/link/macosx/sdl_linker.ads
@@ -6,5 +6,8 @@
 package SDL_Linker is
    pragma Pure;
 
-   Options : constant String := "-F/Library/Frameworks -framework SDL2";
+   pragma Linker_Options ("-F/Library/Frameworks");
+   pragma Linker_Options ("-framework");
+   pragma Linker_Options ("SDL2");
+
 end SDL_Linker;

--- a/src/link/macosx/sdl_linker.ads
+++ b/src/link/macosx/sdl_linker.ads
@@ -6,8 +6,5 @@
 package SDL_Linker is
    pragma Pure;
 
-   pragma Linker_Options ("-F/Library/Frameworks");
-   pragma Linker_Options ("-framework");
-   pragma Linker_Options ("SDL2");
-
+   Options : constant String := "-Wl,-F/Library/Frameworks,-framework,SDL2";
 end SDL_Linker;

--- a/src/link/nix/sdl_linker.ads
+++ b/src/link/nix/sdl_linker.ads
@@ -6,5 +6,5 @@
 package SDL_Linker is
    pragma Pure;
 
-   pragma Linker_Options ("-lSDL2");
+   Options : constant String := "-lSDL2";
 end SDL_Linker;

--- a/src/link/nix/sdl_linker.ads
+++ b/src/link/nix/sdl_linker.ads
@@ -6,5 +6,5 @@
 package SDL_Linker is
    pragma Pure;
 
-   Options : constant String := "-lSDL2";
+   pragma Linker_Options ("-lSDL2");
 end SDL_Linker;

--- a/src/sdl.ads
+++ b/src/sdl.ads
@@ -10,7 +10,6 @@ with SDL_Linker;
 
 package SDL is
    pragma Pure;
-   pragma Linker_Options (SDL_Linker.Options);
 
    package C renames Interfaces.C;
 

--- a/src/sdl.ads
+++ b/src/sdl.ads
@@ -10,6 +10,7 @@ with SDL_Linker;
 
 package SDL is
    pragma Pure;
+   pragma Linker_Options (SDL_Linker.Options);
 
    package C renames Interfaces.C;
 


### PR DESCRIPTION
These changes allow users to import SDL2 using one of Homebrew, MacPorts or the framework from libsdl.org, in that order of preference.

For the framework changes, there are two issues:
* the way that GCC is built means that it doesn't search for frameworks in /Library/Frameworks, so we have to tell it to.
* the linker options can't have spaces, because they need to be passed to ld as separate arguments.

For the CI changes:
* the version of alr used needs to be updated to v2(.0.1), because v1.2 doesn't understand the new os & distribution choices introduced for macOS.
* the macOS workflow needs to run on macos-12; macos-latest now runs on aarch64, and macos-13 uses Xcode 15, with consequent linking problems.

  * alire.toml (gpr-set-externals): if the OS is macos, set SDL_PLATFORM to macos_homebrew (if 'brew' is on the PATH), macos_ports (if 'brew' isn't on the PATH but 'port' is), or macosx (if neither 'brew' nor 'port' is on the PATH).
  * src/sdl.ads (pragma Linker_Options): remove. (SDL_Linker): mark as unreferenced. (query: should it be with'd in the body?)
  * src/link/macosx/sdl_linker.ads: remove Options. Add three Linker_Options, one to specify the location of the framework, one for the '-framework` switch, and one for 'SDL2'.
  * src/link/nix/sdl_linker.ads: replace Options by the equivalent pragma Linker_Options.

  * .github/workflows/ci-linux.yml (setup-alire): use setup-alire@v3. (Install toolchain): 'config' is deprecated, use 'settings'. Remove the 'toolchain --install' lines (option not available).
  * .github/workflows/ci-windows.yaml: likewise.
  * .github/workflows/ci-macos.yml: likewise. (runs-on): change to macos-12.