### PR TITLE
Introduce additional macOS CI using MacPorts, frameworks

### DIFF
--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -32,11 +32,11 @@ jobs:
     -
       name: Install SDL2.framework
       run: |
-        ls ~
         mkdir -p ~/tmp
         curl -L -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg -o ~/tmp/SDL2.dmg
+        xattr -c ~/tmp/SDL2.dmg
         hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
-        cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
+        sudo cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
         hdiutil detach ~/tmp/SDL2
       shell: bash
     -

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -30,20 +30,12 @@ jobs:
       run: rm -f $(which brew)
       shell: bash
     -
-      name: Install SDL2.framework
-      run: |
-        mkdir -p ~/tmp
-        echo "downloading .dmg ..."
-        curl -L -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg -o ~/tmp/SDL2.dmg
-        echo "... removing attributes (specifically, com.apple.quarantine) ..."
-        xattr -c ~/tmp/SDL2.dmg
-        echo "... mounting volume ..."
-        hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
-        echo "... copying framework to /Library/Frameworks ..."
-        sudo cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
-        echo "... done."
-        hdiutil detach ~/tmp/SDL2
-      shell: bash
+      name: Install SDL2.framework to ~/Library/Frameworks
+      uses: BrettDong/setup-sdl2-frameworks@main
+    -
+      name: Copy SDL2.framework to /Library/Frameworks
+      run: sudo cp -pR ~/Library/Frameworks/SDL2.framewwork /Library/Frameworks
+      shwll: bash
     -
       name: Build and run
       run: |

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -34,9 +34,7 @@ jobs:
       uses: BrettDong/setup-sdl2-frameworks@main
     -
       name: Copy SDL2.framework to /Library/Frameworks
-      run: |
-        ls -l ~/Library/Frameworks
-        sudo cp -pR ~/Library/Frameworks/SDL2.framewwork /Library/Frameworks
+      run: sudo cp -pR ~/Library/Frameworks/SDL2.framework /Library/Frameworks
       shell: bash
     -
       name: Build and run

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -32,9 +32,12 @@ jobs:
     -
       name: Install SDL2.framework
       run: |
-        curl -LJ -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg --output ~/tmp/SDL2.dmg
+        ls ~
+        mkdir -p ~/tmp
+        curl -J -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg -o ~/tmp/SDL2.dmg
         hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
         cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
+        hdiutil detach ~/tmp/SDL2
       shell: bash
     -
       name: Build and run

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -35,7 +35,7 @@ jobs:
     -
       name: Copy SDL2.framework to /Library/Frameworks
       run: sudo cp -pR ~/Library/Frameworks/SDL2.framewwork /Library/Frameworks
-      shwll: bash
+      shell: bash
     -
       name: Build and run
       run: |

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -33,12 +33,15 @@ jobs:
       name: Install SDL2.framework
       run: |
         mkdir -p ~/tmp
+        echo "downloading .dmg ..."
         curl -L -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg -o ~/tmp/SDL2.dmg
+        echo "... removing attributes (specifically, com.apple.quarantine) ..."
         xattr -c ~/tmp/SDL2.dmg
+        echo "... mounting volume ..."
         hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
-        echo "copying to /Library/Frameworks"
-        sudo cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
-        ls -1 /Library/Frameworks
+        echo "... moving framework to /Library/Frameworks ..."
+        sudo mv ~/tmp/SDL2/SDL2.framework /Library/Frameworks
+        echo "... done."
         hdiutil detach ~/tmp/SDL2
       shell: bash
     -

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -1,0 +1,42 @@
+---
+
+name: CI macOS (Frameworks)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    name: CI on macOS (Frameworks)
+
+    runs-on: macos-12
+
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v4
+    -
+      name: alire-project/setup-alire
+      uses: alire-project/setup-alire@v3
+    -
+      name: Install toolchain
+      run: |
+        alr --non-interactive settings --global --set toolchain.assistant false
+        alr --non-interactive toolchain --select gnat_native
+        alr --non-interactive toolchain --select gprbuild
+    -
+      name: Disable Homebrew
+      run: rm -f $(which brew)
+      shell: bash
+    -
+      name: Install SDL2.framework
+      run: |
+        curl -LJ -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg --output ~/tmp/SDL2.dmg
+        hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
+        cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
+      shell: bash
+    -
+      name: Build and run
+      run: |
+        alr --non-interactive build

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -34,7 +34,9 @@ jobs:
       uses: BrettDong/setup-sdl2-frameworks@main
     -
       name: Copy SDL2.framework to /Library/Frameworks
-      run: sudo cp -pR ~/Library/Frameworks/SDL2.framewwork /Library/Frameworks
+      run: |
+        ls -l ~/Library/Frameworks
+        sudo cp -pR ~/Library/Frameworks/SDL2.framewwork /Library/Frameworks
       shell: bash
     -
       name: Build and run

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -36,7 +36,9 @@ jobs:
         curl -L -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg -o ~/tmp/SDL2.dmg
         xattr -c ~/tmp/SDL2.dmg
         hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
+        echo "copying to /Library/Frameworks"
         sudo cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
+        ls -1 /Library/Frameworks
         hdiutil detach ~/tmp/SDL2
       shell: bash
     -

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         ls ~
         mkdir -p ~/tmp
-        curl -J -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg -o ~/tmp/SDL2.dmg
+        curl -L -v https://github.com/libsdl-org/SDL/releases/download/release-2.30.3/SDL2-2.30.3.dmg -o ~/tmp/SDL2.dmg
         hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
         cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
         hdiutil detach ~/tmp/SDL2

--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -39,8 +39,8 @@ jobs:
         xattr -c ~/tmp/SDL2.dmg
         echo "... mounting volume ..."
         hdiutil attach -mountpoint ~/tmp/SDL2 ~/tmp/SDL2.dmg
-        echo "... moving framework to /Library/Frameworks ..."
-        sudo mv ~/tmp/SDL2/SDL2.framework /Library/Frameworks
+        echo "... copying framework to /Library/Frameworks ..."
+        sudo cp -pR ~/tmp/SDL2/SDL2.framework /Library/Frameworks
         echo "... done."
         hdiutil detach ~/tmp/SDL2
       shell: bash

--- a/.github/workflows/ci-macos-hb.yml
+++ b/.github/workflows/ci-macos-hb.yml
@@ -1,6 +1,6 @@
 ---
 
-name: CI macOS
+name: CI macOS (Homebrew)
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: CI on macOS
+    name: CI on macOS (Homebrew)
 
     runs-on: macos-12
 

--- a/.github/workflows/ci-macos-mp.yml
+++ b/.github/workflows/ci-macos-mp.yml
@@ -1,0 +1,38 @@
+---
+
+name: CI macOS (Macports)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    name: CI on macOS (Macports)
+
+    runs-on: macos-12
+
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v4
+    -
+      name: alire-project/setup-alire
+      uses: alire-project/setup-alire@v3
+    -
+      name: Install toolchain
+      run: |
+        alr --non-interactive settings --global --set toolchain.assistant false
+        alr --non-interactive toolchain --select gnat_native
+        alr --non-interactive toolchain --select gprbuild
+    -
+      name: Disable Homebrew
+      run: rm -f $(which brew)
+      shell: bash
+    -
+      name: Install MacPorts
+      uses: melusina-org/setup-macports@v1
+    -
+      name: Build and run
+      run: |
+        alr --non-interactive build

--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -83,6 +83,10 @@ library project SDLAda is
                                           "-I/opt/local/include",
                                           "-D_REENTRANT");
 
+         when "macosx" =>
+            C_Switches   := C_Switches & ("-F/Library/Frameworks",
+                                          "-D_THREAD_SAFE");
+
          when others =>
             null;
       end case;


### PR DESCRIPTION
  * .github/workflows/ci-macos-hb.yml: uses Homebrew.
  * .github/workflows/ci-macos-mp.yml: uses MacPorts.
  * .github/workflows/ci-macos.yml: renamed to ci-macos-hb.yml.