### PR TITLE
Add Github CI for Macports, frameworks.

### DIFF
--- a/.github/workflows/ci-macos-fw.yml
+++ b/.github/workflows/ci-macos-fw.yml
@@ -1,0 +1,42 @@
+---
+
+name: CI macOS (Frameworks)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    name: CI on macOS (Frameworks)
+
+    runs-on: macos-12
+
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v4
+    -
+      name: alire-project/setup-alire
+      uses: alire-project/setup-alire@v3
+    -
+      name: Install toolchain
+      run: |
+        alr --non-interactive settings --global --set toolchain.assistant false
+        alr --non-interactive toolchain --select gnat_native
+        alr --non-interactive toolchain --select gprbuild
+    -
+      name: Disable Homebrew
+      run: rm -f $(which brew)
+      shell: bash
+    -
+      name: Install SDL2.framework to ~/Library/Frameworks
+      uses: BrettDong/setup-sdl2-frameworks@main
+    -
+      name: Copy SDL2.framework to /Library/Frameworks
+      run: sudo cp -pR ~/Library/Frameworks/SDL2.framework /Library/Frameworks
+      shell: bash
+    -
+      name: Build and run
+      run: |
+        alr --non-interactive build

--- a/.github/workflows/ci-macos-hb.yml
+++ b/.github/workflows/ci-macos-hb.yml
@@ -1,6 +1,6 @@
 ---
 
-name: CI macOS
+name: CI macOS (Homebrew)
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: CI on macOS
+    name: CI on macOS (Homebrew)
 
     runs-on: macos-12
 

--- a/.github/workflows/ci-macos-mp.yml
+++ b/.github/workflows/ci-macos-mp.yml
@@ -1,0 +1,38 @@
+---
+
+name: CI macOS (Macports)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    name: CI on macOS (Macports)
+
+    runs-on: macos-12
+
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v4
+    -
+      name: alire-project/setup-alire
+      uses: alire-project/setup-alire@v3
+    -
+      name: Install toolchain
+      run: |
+        alr --non-interactive settings --global --set toolchain.assistant false
+        alr --non-interactive toolchain --select gnat_native
+        alr --non-interactive toolchain --select gprbuild
+    -
+      name: Disable Homebrew
+      run: rm -f $(which brew)
+      shell: bash
+    -
+      name: Install MacPorts
+      uses: melusina-org/setup-macports@v1
+    -
+      name: Build and run
+      run: |
+        alr --non-interactive build

--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -83,6 +83,10 @@ library project SDLAda is
                                           "-I/opt/local/include",
                                           "-D_REENTRANT");
 
+         when "macosx" =>
+            C_Switches   := C_Switches & ("-F/Library/Frameworks",
+                                          "-D_THREAD_SAFE");
+
          when others =>
             null;
       end case;


### PR DESCRIPTION
The macOS workflows use actions/checkout@v4, alire-project/setup-alire@v3.

The Macports CI disables Homebrew and installs Macports.

The Frameworks CI disables Homebrew. It uses the
BrettDong/setup-sdl2-frameworks action to retrieve the latest SDL2.framework, and copies it to /Library/Frameworks, where this crate expects it.

  * .github/workflows/ci-macos-hb.yml: renamed from ci-macos.yml. Uses Homebrew.
  * .github/workflows/ci-macos-mp.yml: new. Uses MacPorts.
  * .github/workflows/ci-macos.yml: renamed to ci-macos-hb.yml.
  * .github/workflows/ci-macos-fw.yml: new. Uses SDL2.framework.